### PR TITLE
Remove old policy set definition

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       major: '1'
       minor: '14'
-      patch: '3'
+      patch: '4'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:      

--- a/AzLandingZone/Private/PowerShell/Set-PolicyDiagnosticStorage.ps1
+++ b/AzLandingZone/Private/PowerShell/Set-PolicyDiagnosticStorage.ps1
@@ -63,9 +63,24 @@ Function Set-PolicyDiagnosticStorage {
             if ($policy.Properties.metadata.version -eq $policyVersion) {
                 Write-Host "$policyName is up-to-date"
             } else {
+                Write-Host "Update policy: $policyName"
                 Invoke-WebRequest -Uri $policyLink -OutFile $HOME/$policyName.json
                 $metadata = '{"version":"' + $policyVersion + '"}'
-                $policy = Set-AzPolicyDefinition -Id $policy.ResourceId -Policy $HOME/$policyName.json -Metadata $metadata
+                if($policy.Properties.Parameters.region){
+                    # Policy is still an old version that uses region parameter. To be deleted.
+                    if ($policyInitiative = Get-AzPolicySetDefinition -ManagementGroupName $GetManagementGroup.Name | where-Object { $_.Name -Like "SLZ-policyGroup1" }) {
+                        if($assignment = (Get-AzPolicyAssignment -Scope $scope | Where-Object {$_.Name -Like "SLZ-policyGroup1"})) {
+                            Remove-AzPolicyAssignment -InputObject $assignment
+                            Start-Sleep -Seconds 15
+                        }
+                        Remove-AzPolicySetDefinition -ManagementGroupName $GetManagementGroup.Name -Name "SLZ-policyGroup1" -Force
+                    }
+                    Remove-AzPolicyDefinition -InputObject $policy -Force
+                    Start-Sleep -Seconds 15
+                    $policy = New-AzPolicyDefinition -ManagementGroupName $GetManagementGroup.Name -Name $policyName -Policy $HOME/$policyName.json -Parameter $HOME/parameters.json -Metadata $metadata
+                } else {         
+                    $policy = Set-AzPolicyDefinition -Id $policy.ResourceId -Policy $HOME/$policyName.json -Metadata $metadata
+                }
                 Remove-Item -Path $HOME/$policyName.json
                 Write-Host "Updated policy: $policyName"
             }

--- a/AzLandingZone/Private/PowerShell/Set-PolicyDiagnosticWorkspace.ps1
+++ b/AzLandingZone/Private/PowerShell/Set-PolicyDiagnosticWorkspace.ps1
@@ -63,9 +63,24 @@ Function Set-PolicyDiagnosticWorkspace {
             if ($policy.Properties.metadata.version -eq $policyVersion) {
                 Write-Host "$policyName is up-to-date"
             } else {
+                Write-Host "Update policy: $policyName"
                 Invoke-WebRequest -Uri $policyLink -OutFile $HOME/$policyName.json
                 $metadata = '{"version":"' + $policyVersion + '"}'
-                $policy = Set-AzPolicyDefinition -Id $policy.ResourceId -Policy $HOME/$policyName.json -Metadata $metadata
+                if($policy.Properties.Parameters.region){
+                    # Policy is still an old version that uses region parameter. To be deleted.
+                    if ($policyInitiative = Get-AzPolicySetDefinition -ManagementGroupName $GetManagementGroup.Name | where-Object { $_.Name -Like "SLZ-policyGroup2" }) {
+                        if($assignment = (Get-AzPolicyAssignment -Scope $scope | Where-Object {$_.Name -Like "SLZ-policyGroup2"})) {
+                            Remove-AzPolicyAssignment -InputObject $assignment
+                            Start-Sleep -Seconds 15
+                        }
+                        Remove-AzPolicySetDefinition -ManagementGroupName $GetManagementGroup.Name -Name "SLZ-policyGroup2" -Force
+                    }
+                    Remove-AzPolicyDefinition -InputObject $policy -Force
+                    Start-Sleep -Seconds 15
+                    $policy = New-AzPolicyDefinition -ManagementGroupName $GetManagementGroup.Name -Name $policyName -Policy $HOME/$policyName.json -Parameter $HOME/parameters.json -Metadata $metadata
+                } else {         
+                    $policy = Set-AzPolicyDefinition -Id $policy.ResourceId -Policy $HOME/$policyName.json -Metadata $metadata
+                }
                 Remove-Item -Path $HOME/$policyName.json
                 Write-Host "Updated policy: $policyName"
             }


### PR DESCRIPTION
Removes old policy set definition if it still uses region to be able to recreate it afterwards with the proper configuration