### PR TITLE
@119 changed use of azcli api to use -id in place of -objectId

### DIFF
--- a/AzLandingZone/Public/Test-AzLandingZone.ps1
+++ b/AzLandingZone/Public/Test-AzLandingZone.ps1
@@ -28,7 +28,7 @@ Function Test-AzLandingZone {
     Param()
 
     # Get current user information
-    $servicePrincipalId = az ad signed-in-user show --query objectId -o tsv
+    $servicePrincipalId = az ad signed-in-user show --query id -o tsv
     $currentUser = Get-AzADUser | Where-Object { $_.Id -eq $servicePrincipalId }
     Write-Verbose "Currently connected as '$($currentUser.DisplayName)'"
 


### PR DESCRIPTION

This no longer works

```
$ az ad signed-in-user show --query objectId -o tsv
<returns nothing>
```

Replaced with the following that does work

```
$ az ad signed-in-user show --query id -o tsv
2f40dad4-39fb-4b66-9293-173f034cec3f
```