### PR TITLE
Feature/127 immutability policy for test

### DIFF
--- a/AzLandingZone/Private/PowerShell/setup-Storage.ps1
+++ b/AzLandingZone/Private/PowerShell/setup-Storage.ps1
@@ -41,12 +41,26 @@ Function setup-Storage {
     # If storage is not immutable, set immutability to 185 days
     # Migrate Immutability policy to Az module instead of AzureRM
     #
-    Write-Verbose "Checking Azure Landing Zone Storage account immutability policy"
-    if(((Get-AzRmStorageContainerImmutabilityPolicy -StorageAccountName $GetStorageAccount.StorageAccountName -ResourceGroupName $GetResourceGroup.ResourceGroupName -ContainerName "landingzonelogs").ImmutabilityPeriodSinceCreationInDays) -eq 0){
-        #$blob = Set-AzStorageBlobImmutabilityPolicy -Container $container.Name -PolicyMode Unlocked -ExpiresOn (GetDate).AddDays($retentionPeriod)
-        $policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
-        Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
-        Write-Verbose "Created immutability policy for $retentionPeriod days"
+    if($name -Like "*test*"){
+        Write-Verbose "In test mode - so do not create an immutability policy for storage account"
+    } else {    
+        Write-Verbose "Checking Azure Landing Zone Storage account immutability policy"
+        if(((Get-AzRmStorageContainerImmutabilityPolicy -StorageAccountName $GetStorageAccount.StorageAccountName -ResourceGroupName $GetResourceGroup.ResourceGroupName -ContainerName "landingzonelogs").ImmutabilityPeriodSinceCreationInDays) -eq 0){
+            #$blob = Set-AzStorageBlobImmutabilityPolicy -Container $container.Name -PolicyMode Unlocked -ExpiresOn (GetDate).AddDays($retentionPeriod)
+            $policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
+            Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
+            Write-Verbose "Created immutability policy for $retentionPeriod days"
+        }
     }
 }
 Export-ModuleMember -Function setup-Storage
+
+if($name -Like "*test*"){
+    Write-Verbose "In test mode so do not create an immutability policy for $retentionPeriod days"
+} else {
+    Write-Error "This should not be called"
+
+    #$policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
+    #Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
+    #Write-Verbose "Created immutability policy for $retentionPeriod days"
+}

--- a/AzLandingZone/Private/PowerShell/setup-Storage.ps1
+++ b/AzLandingZone/Private/PowerShell/setup-Storage.ps1
@@ -54,13 +54,3 @@ Function setup-Storage {
     }
 }
 Export-ModuleMember -Function setup-Storage
-
-if($name -Like "*test*"){
-    Write-Verbose "In test mode so do not create an immutability policy for $retentionPeriod days"
-} else {
-    Write-Error "This should not be called"
-
-    #$policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
-    #Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
-    #Write-Verbose "Created immutability policy for $retentionPeriod days"
-}

--- a/AzLandingZone/Private/PowerShell/setup-Storage.ps1
+++ b/AzLandingZone/Private/PowerShell/setup-Storage.ps1
@@ -41,11 +41,10 @@ Function setup-Storage {
     # If storage is not immutable, set immutability to 185 days
     # Migrate Immutability policy to Az module instead of AzureRM
     #
+    Write-Verbose "Checking Azure Landing Zone Storage account immutability policy"
     if($name -Like "*test*"){
         Write-Verbose "In test mode - so do not create an immutability policy for storage account"
-    } else {    
-        Write-Verbose "Checking Azure Landing Zone Storage account immutability policy"
-        if(((Get-AzRmStorageContainerImmutabilityPolicy -StorageAccountName $GetStorageAccount.StorageAccountName -ResourceGroupName $GetResourceGroup.ResourceGroupName -ContainerName "landingzonelogs").ImmutabilityPeriodSinceCreationInDays) -eq 0){
+    } else if(((Get-AzRmStorageContainerImmutabilityPolicy -StorageAccountName $GetStorageAccount.StorageAccountName -ResourceGroupName $GetResourceGroup.ResourceGroupName -ContainerName "landingzonelogs").ImmutabilityPeriodSinceCreationInDays) -eq 0){
             #$blob = Set-AzStorageBlobImmutabilityPolicy -Container $container.Name -PolicyMode Unlocked -ExpiresOn (GetDate).AddDays($retentionPeriod)
             $policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
             Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force

--- a/AzLandingZone/Private/PowerShell/setup-Storage.ps1
+++ b/AzLandingZone/Private/PowerShell/setup-Storage.ps1
@@ -45,11 +45,10 @@ Function setup-Storage {
     if($name -Like "*test*"){
         Write-Verbose "In test mode - so do not create an immutability policy for storage account"
     } else if(((Get-AzRmStorageContainerImmutabilityPolicy -StorageAccountName $GetStorageAccount.StorageAccountName -ResourceGroupName $GetResourceGroup.ResourceGroupName -ContainerName "landingzonelogs").ImmutabilityPeriodSinceCreationInDays) -eq 0){
-            #$blob = Set-AzStorageBlobImmutabilityPolicy -Container $container.Name -PolicyMode Unlocked -ExpiresOn (GetDate).AddDays($retentionPeriod)
-            $policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
-            Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
-            Write-Verbose "Created immutability policy for $retentionPeriod days"
-        }
+        #$blob = Set-AzStorageBlobImmutabilityPolicy -Container $container.Name -PolicyMode Unlocked -ExpiresOn (GetDate).AddDays($retentionPeriod)
+        $policy = Set-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -ImmutabilityPeriod $retentionPeriod
+        Lock-AzRmStorageContainerImmutabilityPolicy -ResourceGroupName $GetResourceGroup.ResourceGroupName -StorageAccountName $GetStorageAccount.StorageAccountName -ContainerName "landingzonelogs" -Etag $policy.Etag -Force
+        Write-Verbose "Created immutability policy for $retentionPeriod days"
     }
 }
 Export-ModuleMember -Function setup-Storage


### PR DESCRIPTION
A CI/CD pipeline needs to clean up all resources after a test deployment.

- Setting an 'immutability policy' means it is impossible to delete Blob Containers
- This change disables the the  'immutability policy' if the resource group name contains the word 'test'

I've set this as a draft pull request but could you give me feedback to see if this is 1) okay and 2) are there any other issues like this?

Thx
